### PR TITLE
Use codeframe to format lint output

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "build:typedefs": "lerna run build:typedefs --stream",
     "test": "run-p test:tsc test:lint test:coverage",
     "test:lint": "run-p -c test:lint:*",
-    "test:lint:ts": "eslint --ext .js,.ts,.tsx ./",
+    "test:lint:ts": "eslint -f codeframe --ext .js,.ts,.tsx ./",
     "test:lint:css": "stylelint \"packages/**/*.ts{,x}\"",
     "test:lint:md": "markdownlint ./docs/ ./packages/ ./testing/ ./*.md",
     "test:coverage": "jest --coverage",


### PR DESCRIPTION
I think this format of linter output will be more friendly for people joining the project

![image](https://user-images.githubusercontent.com/10697525/62251557-0473e700-b3e8-11e9-8643-b8f099eb3908.png)
